### PR TITLE
Add Quick Next/previous Features to DataContainer

### DIFF
--- a/src/FluentMarvelSdk/Extensions/ObjectExtensions.cs
+++ b/src/FluentMarvelSdk/Extensions/ObjectExtensions.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace FluentMarvelSdk;
+
+public static class ObjectExtensions
+{
+    public static T CreateDeepCopy<T>(this T obj)
+    {
+        string json = JsonSerializer.Serialize(obj);
+        return JsonSerializer.Deserialize<T>(json)!;
+    }
+}

--- a/src/FluentMarvelSdk/Models/Character/CharacterRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Character/CharacterRequestBuilder.cs
@@ -68,38 +68,4 @@ public class CharacterRequestBuilder : ResourceRequestBuilder<Character, Charact
         OptionSet.NameStartsWith = nameStartsWith;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public CharacterRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public CharacterRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only characters modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public CharacterRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
 }

--- a/src/FluentMarvelSdk/Models/Comic/ComicRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Comic/ComicRequestBuilder.cs
@@ -236,38 +236,4 @@ public class ComicRequestBuilder : ResourceRequestBuilder<Comic, ComicOptionSet>
         OptionSet.Collaborators = collaboratorIds;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public ComicRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public ComicRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only characters modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public ComicRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
 }

--- a/src/FluentMarvelSdk/Models/Creator/CreatorRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Creator/CreatorRequestBuilder.cs
@@ -128,38 +128,4 @@ public class CreatorRequestBuilder : ResourceRequestBuilder<Creator, CreatorOpti
         OptionSet.Stories = storyIds;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public CreatorRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public CreatorRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only creators modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public CreatorRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
 }

--- a/src/FluentMarvelSdk/Models/DataContainer.cs
+++ b/src/FluentMarvelSdk/Models/DataContainer.cs
@@ -2,9 +2,24 @@ namespace FluentMarvelSdk;
 
 public class DataContainer<T>
 {
+    // Public Properties
+    public IResourceRequestBuilder<T>? Previous { get; private set; }
+    public IResourceRequestBuilder<T>? Next { get; private set; }
+
+
     public int? Offset { get; set; }
     public int? Limit { get; set; }
     public int? Total { get; set; }
     public int? Count { get; set; }
     public IEnumerable<T>? Results { get; set; }
+
+    internal void SetPreviousBuilder(IResourceRequestBuilder<T> previousBuilder)
+    {
+        Previous = previousBuilder;
+    }
+
+    internal void SetNextBuilder(IResourceRequestBuilder<T> nextBuilder)
+    {
+        Next = nextBuilder;
+    }
 }

--- a/src/FluentMarvelSdk/Models/Event/EventRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Event/EventRequestBuilder.cs
@@ -78,38 +78,4 @@ public class EventRequestBuilder : ResourceRequestBuilder<Event, EventOptionSet>
         OptionSet.Stories = storyIds;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public EventRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public EventRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only characters modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public EventRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
 }

--- a/src/FluentMarvelSdk/Models/ResourceRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/ResourceRequestBuilder.cs
@@ -1,6 +1,6 @@
 namespace FluentMarvelSdk;
 
-public abstract class ResourceRequestBuilder<T, TOptionSet>
+public abstract class ResourceRequestBuilder<T, TOptionSet> where TOptionSet : OptionSet
 {
     public TOptionSet OptionSet { get; init; }
     protected MarvelApiService _service;
@@ -25,5 +25,39 @@ public abstract class ResourceRequestBuilder<T, TOptionSet>
         url.SetQueryParams<TOptionSet>(OptionSet);
 
         return await _service.GetResourceAsync<T>(url);
+    }
+
+    /// <summary>
+    /// Limit the returned results.
+    /// </summary>
+    /// <param name="limit"></param>
+    public  ResourceRequestBuilder<T, TOptionSet> LimitResultsBy(int limit)
+    {
+        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
+        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
+        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
+
+        OptionSet.Limit = limit;
+        return this;
+    }
+
+    /// <summary>
+    /// Skips the specified number of results.
+    /// </summary>
+    /// <param name="offset"></param>
+    public  ResourceRequestBuilder<T, TOptionSet> OffsetResultsBy(int offset)
+    {
+        OptionSet.Offset = offset;
+        return this;
+    }
+
+    /// <summary>
+    /// Filters the request to return only characters modified since <see cref="date"/>.
+    /// </summary>
+    /// <param name="date"></param>
+    public ResourceRequestBuilder<T, TOptionSet> ModifiedSince(DateOnly date)
+    {
+        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
+        return this;
     }
 }

--- a/src/FluentMarvelSdk/Models/Series/SeriesRequetBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Series/SeriesRequetBuilder.cs
@@ -89,38 +89,4 @@ public class SeriesRequestBuilder : ResourceRequestBuilder<Series, SeriesOptionS
         OptionSet.SeriesType = seriesFrequencyType;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public SeriesRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public SeriesRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only characters modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public SeriesRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
 }

--- a/src/FluentMarvelSdk/Models/Story/StoryRequestBuilder.cs
+++ b/src/FluentMarvelSdk/Models/Story/StoryRequestBuilder.cs
@@ -57,40 +57,4 @@ public class StoryRequestBuilder : ResourceRequestBuilder<Story, StoryOptionSet>
         OptionSet.Characters = characterIds;
         return this;
     }
-
-    /// <summary>
-    /// Limit the returned results.
-    /// </summary>
-    /// <param name="limit"></param>
-    public StoryRequestBuilder LimitResultsBy(int limit)
-    {
-        // Try to block uneeded calls to the API by validating this parameter locally. At the mercy of the API changing, but...
-        if (limit < Constants.LimitLowerBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be above {Constants.LimitLowerBound}" });
-        if (limit > Constants.LimitUpperBound) throw new InvalidLimitException(new ApiError() { Message = $"Limit must be less than or equal to {Constants.LimitUpperBound}" });
-
-        OptionSet.Limit = limit;
-        return this;
-    }
-
-    /// <summary>
-    /// Skips the specified number of results.
-    /// </summary>
-    /// <param name="offset"></param>
-    public StoryRequestBuilder OffsetResultsBy(int offset)
-    {
-        OptionSet.Offset = offset;
-        return this;
-    }
-
-    /// <summary>
-    /// Filters the request to return only characters modified since <see cref="date"/>.
-    /// </summary>
-    /// <param name="date"></param>
-    public StoryRequestBuilder ModifiedSince(DateOnly date)
-    {
-        OptionSet.ModifiedSince = new(date.Year, date.Month, date.Day, 0, 0, 0, TimeSpan.FromHours(10));
-        return this;
-    }
-
-
 }

--- a/src/TestHarness/Program.cs
+++ b/src/TestHarness/Program.cs
@@ -16,7 +16,7 @@ var serializerOptions = new JsonSerializerOptions()
 var api = new MarvelApiService(_configuration["Marvel:PrivateKey"], _configuration["Marvel:PublicKey"]);
 
 var characters = await api.GetCharacters()
-    .LimitResultsBy(1000)
+    .LimitResultsBy(10)
     .Excelsior();
 
 


### PR DESCRIPTION
Closes #15 by introducing Next/Previous properties to the DataContainer object.  These are populated during `Excelsior()` to, based upon the `Limit` property on the options object, to create a builder that will be the either the previous `Limit` entries or the next `Limit` entries.

Although this eases traversal through the API, it's reccomended to use this sparingly as, with low limits, it can consume Marvel Comic API calls quickly.